### PR TITLE
Fix bug under iOS7

### DIFF
--- a/lib/AlertContainer.js
+++ b/lib/AlertContainer.js
@@ -198,7 +198,7 @@ class AlertContainer extends Component {
 				]}>
 					{props.children}
 				</Text>
-				{props.message && <Text style={[styles.message, props.textStyle,]}>{props.message}</Text>}
+				{props.message ? <Text style={[styles.message, props.textStyle,]}>{props.message}</Text> : null}
 				{this._renderButtons(props.buttons) }
 			</View>
 		</View>;


### PR DESCRIPTION
`{props.message && <Text style={[styles.message, props.textStyle,]}>{props.message}</Text>}`

This is not support under iOS7, fix it using ?: operator.